### PR TITLE
Fix typo in default token

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -5,7 +5,7 @@ runs:
   using: 'docker'
   image: 'Dockerfile'
 env:
-  GITHUB_TOKEN: secrects.GITHUB_TOKEN
+  GITHUB_TOKEN: secrets.GITHUB_TOKEN
 branding:
   icon: 'code'
   color: 'red'


### PR DESCRIPTION
Fixes a typo in the retrieval of the default `GITHUB_TOKEN` env var.