### PR TITLE
Bump Crystal to 1.16.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM crystallang/crystal:1.15.1
+FROM crystallang/crystal:1.16.2
 
 LABEL maintainer="Vitalii Elenhaupt <velenhaupt@gmail.com>"
 LABEL com.github.actions.name="Ameba checks"


### PR DESCRIPTION
Build application against the crystal 1.16.2.

I wonder if it could be controlled via the Github Action it self and use something like: `latest`.