### PR TITLE
Add basic action inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,14 @@ linter.
 
 ![](https://github.com/crystal-ameba/github-action/raw/master/assets/sample.png)
 
+## Inputs
+
+| Input name     | Description                                  | Required? | Default value  |
+|----------------|----------------------------------------------|-----------|----------------|
+| `config`       | Path to the configuration file               | ✗         | —              |
+| `version`      | Version of Ameba ruleset to check against    | ✗         | —              |
+| `min-severity` | Minimum severity of issues to report         | ✗         | `convention`   |
+
 ## Usage
 
 To use Crystal Ameba Linter, add the following step to your GitHub action workflow:
@@ -36,6 +44,10 @@ jobs:
 
       - name: Run Ameba Linter
         uses: crystal-ameba/github-action@master
+        with:
+          config: .ameba.ci.yml
+          version: 1.6.0
+          min-severity: warning
 ```
 
 ## Compatibility Versions

--- a/action.yml
+++ b/action.yml
@@ -2,6 +2,10 @@ name: Crystal Ameba Linter
 description: A GitHub Action that lints Crystal code with Ameba
 author: Vitalii Elenhaupt <velenhaupt@gmail.com>
 
+branding:
+  icon: code
+  color: red
+
 inputs:
   config:
     description: Path to Ameba configuration file
@@ -23,7 +27,3 @@ runs:
     - "${{ inputs.version }}"
     - "--min-severity"
     - "${{ inputs.min-severity }}"
-
-branding:
-  icon: code
-  color: red

--- a/action.yml
+++ b/action.yml
@@ -2,9 +2,27 @@ name: Crystal Ameba Linter
 description: A GitHub Action that lints Crystal code with Ameba
 author: Vitalii Elenhaupt <velenhaupt@gmail.com>
 
+inputs:
+  config:
+    description: Path to Ameba configuration file
+  version:
+    description: Version of Ameba rules to use
+  min-severity:
+    description: Minimum severity of issues to report
+
 runs:
   using: docker
   image: Dockerfile
+  entrypoint: /usr/bin/ameba
+  args:
+    - "--format"
+    - "github-actions"
+    - "--config"
+    - "${{ inputs.config }}"
+    - "--up-to-version"
+    - "${{ inputs.version }}"
+    - "--min-severity"
+    - "${{ inputs.min-severity }}"
 
 branding:
   icon: code


### PR DESCRIPTION
Adds `config`, `version`, and `min-severity` inputs to the GHA — example GHA [run](https://github.com/crystal-ameba/github-action/actions/runs/20907820971).

Resolves #24